### PR TITLE
Add fixture type defaults and recompute attributes on type change

### DIFF
--- a/src/wizard/FixtureGroupGrid.jsx
+++ b/src/wizard/FixtureGroupGrid.jsx
@@ -7,6 +7,27 @@ const FIXTURE_TYPES = [
   'LED PAR', 'LED Bar / Batten', 'Strobe', 'Blinder', 'Other',
 ]
 
+const BASE_ATTRIBUTES = {
+  pt: false,
+  rgb: false,
+  colorWheel: false,
+  strobe: false,
+  dimmer: true,
+  zoom: false,
+  gobo: false,
+}
+
+const FIXTURE_TYPE_DEFAULTS = {
+  'Moving Head (Beam)': { ...BASE_ATTRIBUTES, pt: true, colorWheel: true, strobe: true, dimmer: true, gobo: true },
+  'Moving Head (Spot)': { ...BASE_ATTRIBUTES, pt: true, colorWheel: true, strobe: true, dimmer: true, zoom: true, gobo: true },
+  'Moving Head (Wash)': { ...BASE_ATTRIBUTES, pt: true, rgb: true, strobe: true, dimmer: true, zoom: true },
+  'LED PAR': { ...BASE_ATTRIBUTES, rgb: true, strobe: true, dimmer: true },
+  'LED Bar / Batten': { ...BASE_ATTRIBUTES, rgb: true, strobe: true, dimmer: true },
+  'Strobe': { ...BASE_ATTRIBUTES, strobe: true, dimmer: true },
+  'Blinder': { ...BASE_ATTRIBUTES, dimmer: true, strobe: true },
+  'Other': { ...BASE_ATTRIBUTES, dimmer: true },
+}
+
 const ATTRIBUTES = [
   { key: 'pt',         label: 'Pan / Tilt' },
   { key: 'rgb',        label: 'RGB' },
@@ -17,12 +38,18 @@ const ATTRIBUTES = [
   { key: 'gobo',       label: 'Gobo Wheel' },
 ]
 
+const getDefaultAttributes = (fixtureType) => ({
+  ...BASE_ATTRIBUTES,
+  ...(FIXTURE_TYPE_DEFAULTS[fixtureType] || FIXTURE_TYPE_DEFAULTS.Other),
+})
+
 const emptyGroup = () => ({
   id: Date.now() + Math.random(),
   name: '',
   fixtureType: FIXTURE_TYPES[0],
   maGroupName: '',
-  attributes: { pt: false, rgb: false, colorWheel: false, strobe: false, dimmer: true, zoom: false, gobo: false },
+  attributesCustomized: false,
+  attributes: getDefaultAttributes(FIXTURE_TYPES[0]),
 })
 
 export default function FixtureGroupGrid() {
@@ -42,8 +69,25 @@ export default function FixtureGroupGrid() {
   const updateAttr = (id, attrKey, value) => {
     updateSession({
       fixtureGroups: groups.map(g =>
-        g.id === id ? { ...g, attributes: { ...g.attributes, [attrKey]: value } } : g
+        g.id === id
+          ? { ...g, attributesCustomized: true, attributes: { ...g.attributes, [attrKey]: value } }
+          : g
       ),
+    })
+  }
+
+  const updateFixtureType = (id, fixtureType) => {
+    updateSession({
+      fixtureGroups: groups.map((g) => {
+        if (g.id !== id) return g
+
+        const defaults = getDefaultAttributes(fixtureType)
+        const attributes = g.attributesCustomized
+          ? { ...defaults, ...g.attributes }
+          : defaults
+
+        return { ...g, fixtureType, attributes }
+      }),
     })
   }
 
@@ -112,7 +156,7 @@ export default function FixtureGroupGrid() {
               <select
                 className={styles.input}
                 value={group.fixtureType}
-                onChange={e => update(group.id, 'fixtureType', e.target.value)}
+                onChange={e => updateFixtureType(group.id, e.target.value)}
                 style={{ cursor: 'pointer' }}
               >
                 {FIXTURE_TYPES.map(t => <option key={t}>{t}</option>)}


### PR DESCRIPTION
### Motivation
- Ensure fixture-type defaults are centralized so new groups and type changes use the same canonical attribute set.
- Make it easy to recompute attributes when the fixture type changes while preserving any manual operator overrides.

### Description
- Introduce `BASE_ATTRIBUTES` and `FIXTURE_TYPE_DEFAULTS` and a helper `getDefaultAttributes()` to centralize per-type attribute defaults in `src/wizard/FixtureGroupGrid.jsx`.
- Change `emptyGroup()` to initialize new groups using `getDefaultAttributes()` and add an `attributesCustomized` flag to track manual edits.
- Update `updateAttr()` to set `attributesCustomized: true` when a checkbox is toggled so manual overrides are remembered.
- Replace the `<select>` `onChange` handler with `updateFixtureType()` which sets `fixtureType`, recomputes attributes from the defaults, and preserves manual overrides when `attributesCustomized` is true.

### Testing
- Ran `npx vite build` and the frontend bundle built successfully (`vite` build passed).
- Ran `npm run build` and the Vite step passed but `electron-builder` packaging failed due to an environment-specific download error fetching Electron from GitHub (packaging failure unrelated to the code changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7202f936c8323b6a03396ee2985f1)