### PR TITLE
Remove fixture group "Friendly Name" from wizard

### DIFF
--- a/src/store/appState.js
+++ b/src/store/appState.js
@@ -22,7 +22,7 @@ const useStore = create((set, get) => ({
   // ── Session config (set during wizard) ─────────────────────────────────────
   session: {
     name: '',
-    fixtureGroups: [],      // [{ name, fixtureType, attributes: {pt, rgb, colorWheel, strobe, dimmer, zoom} }]
+    fixtureGroups: [],      // [{ fixtureType, attributes: {pt, rgb, colorWheel, strobe, dimmer, zoom} }]
     avoidColors: [],        // [{ h, s, l, label }]
     emphasizeColors: [],    // [{ h, s, l, label }]
     tonightContexts: [],    // ['edm', 'hiphop', ...]

--- a/src/wizard/FixtureGroupGrid.jsx
+++ b/src/wizard/FixtureGroupGrid.jsx
@@ -19,7 +19,6 @@ const ATTRIBUTES = [
 
 const emptyGroup = () => ({
   id: Date.now() + Math.random(),
-  name: '',
   fixtureType: FIXTURE_TYPES[0],
   maGroupName: '',
   attributes: { pt: false, rgb: false, colorWheel: false, strobe: false, dimmer: true, zoom: false, gobo: false },
@@ -96,15 +95,6 @@ export default function FixtureGroupGrid() {
                 placeholder="e.g. Moving Heads or Group 3"
                 value={group.maGroupName}
                 onChange={e => update(group.id, 'maGroupName', e.target.value)}
-              />
-            </div>
-            <div style={{ flex: 2 }}>
-              <div className={styles.label}>Friendly Name</div>
-              <input
-                className={styles.input}
-                placeholder="e.g. Stage movers"
-                value={group.name}
-                onChange={e => update(group.id, 'name', e.target.value)}
               />
             </div>
             <div style={{ flex: 2 }}>


### PR DESCRIPTION
### Motivation
- The wizard was persisting a redundant `name`/"Friendly Name" for fixture groups which is no longer needed and should be removed from saved session payloads.
- Keep the `session.fixtureGroups` shape consistent and avoid storing unused fields in saved profiles.

### Description
- Removed the "Friendly Name" input block from the fixture groups UI in `src/wizard/FixtureGroupGrid.jsx` and stopped reading/writing `group.name` there.
- Removed `name` from newly-created group objects by updating `emptyGroup()` in `src/wizard/FixtureGroupGrid.jsx`.
- Updated the `session.fixtureGroups` shape comment in `src/store/appState.js` to no longer document a `name` key.

### Testing
- Verified no remaining references with ripgrep: `rg -n "group\.name|Friendly Name|\{\s*name,\s*fixtureType|update\(group\.id, 'name'|name:\s*''\s*,\s*$" src` which returned only the updated `appState` entry prior to the change and no active `group.name` usages.
- Ran `npm run build` where the Vite build completed successfully but `electron-builder` failed in this environment due to an external download being blocked (environmental/network issue), so packaging did not complete.
- Launched the dev server (`npm run dev`) and captured a screenshot of the Fixture Groups step to confirm the UI no longer shows the Friendly Name field.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b72083cce48323ae2bdd95402de424)