### PR TITLE
Split custom color add flow into Avoid/Emphasize actions

### DIFF
--- a/src/wizard/ColorPreferences.jsx
+++ b/src/wizard/ColorPreferences.jsx
@@ -44,32 +44,70 @@ export default function ColorPreferences() {
   const { session, updateSession } = useStore()
   const [customHue, setCustomHue] = useState(200)
   const [customLabel, setCustomLabel] = useState('')
+  const [colorNotice, setColorNotice] = useState('')
 
   const avoidColors = session.avoidColors || []
   const emphasizeColors = session.emphasizeColors || []
 
-  const addAvoid = (color) => {
-    if (avoidColors.find(c => c.label === color.label)) return
-    updateSession({ avoidColors: [...avoidColors, color] })
+  const addColorToTarget = ({ target, color }) => {
+    const trimmedLabel = color.label.trim()
+    if (!trimmedLabel) {
+      setColorNotice('Please provide a label for the custom color.')
+      return false
+    }
+
+    const normalizedLabel = trimmedLabel.toLowerCase()
+    const nextColor = { h: color.h, s: color.s, l: color.l, label: trimmedLabel }
+    const isAvoidTarget = target === 'avoid'
+    const targetList = isAvoidTarget ? avoidColors : emphasizeColors
+    const otherList = isAvoidTarget ? emphasizeColors : avoidColors
+
+    if (targetList.some(c => c.label.toLowerCase() === normalizedLabel)) {
+      setColorNotice(`"${trimmedLabel}" is already in ${isAvoidTarget ? 'Avoid' : 'Emphasize'}.`)
+      return false
+    }
+
+    const conflictInOther = otherList.some(c => c.label.toLowerCase() === normalizedLabel)
+    if (conflictInOther) {
+      setColorNotice(`Moved "${trimmedLabel}" from ${isAvoidTarget ? 'Emphasize' : 'Avoid'} to ${isAvoidTarget ? 'Avoid' : 'Emphasize'}.`)
+      updateSession({
+        avoidColors: isAvoidTarget
+          ? [...avoidColors, nextColor]
+          : avoidColors.filter(c => c.label.toLowerCase() !== normalizedLabel),
+        emphasizeColors: isAvoidTarget
+          ? emphasizeColors.filter(c => c.label.toLowerCase() !== normalizedLabel)
+          : [...emphasizeColors, nextColor],
+      })
+      return true
+    }
+
+    setColorNotice('')
+    updateSession({
+      [isAvoidTarget ? 'avoidColors' : 'emphasizeColors']: [...targetList, nextColor],
+    })
+    return true
   }
+
+  const createCustomColor = () => ({ h: customHue, s: 80, l: 50, label: customLabel })
+
+  const addAvoid = (color) => addColorToTarget({ target: 'avoid', color })
 
   const removeAvoid = (label) => {
     updateSession({ avoidColors: avoidColors.filter(c => c.label !== label) })
   }
 
-  const addEmphasize = (color) => {
-    if (emphasizeColors.find(c => c.label === color.label)) return
-    updateSession({ emphasizeColors: [...emphasizeColors, color] })
-  }
+  const addEmphasize = (color) => addColorToTarget({ target: 'emphasize', color })
 
   const removeEmphasize = (label) => {
     updateSession({ emphasizeColors: emphasizeColors.filter(c => c.label !== label) })
   }
 
-  const addCustomAvoid = () => {
-    if (!customLabel.trim()) return
-    addAvoid({ h: customHue, s: 80, l: 50, label: customLabel.trim() })
-    setCustomLabel('')
+  const addCustomColorToAvoid = () => {
+    if (addAvoid(createCustomColor())) setCustomLabel('')
+  }
+
+  const addCustomColorToEmphasize = () => {
+    if (addEmphasize(createCustomColor())) setCustomLabel('')
   }
 
   return (
@@ -135,17 +173,29 @@ export default function ColorPreferences() {
               placeholder="e.g. Company blue"
               value={customLabel}
               onChange={e => setCustomLabel(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && addCustomAvoid()}
+              onKeyDown={e => e.key === 'Enter' && addCustomColorToAvoid()}
             />
           </div>
-          <button
-            className={styles.btnPrimary}
-            style={{ marginTop: 18, padding: '8px 16px' }}
-            onClick={addCustomAvoid}
-          >
-            Add
-          </button>
+          <div style={{ display: 'flex', gap: 8, marginTop: 18 }}>
+            <button
+              className={styles.btnSecondary}
+              style={{ padding: '8px 16px' }}
+              onClick={addCustomColorToAvoid}
+            >
+              Add to Avoid
+            </button>
+            <button
+              className={styles.btnPrimary}
+              style={{ padding: '8px 16px' }}
+              onClick={addCustomColorToEmphasize}
+            >
+              Add to Emphasize
+            </button>
+          </div>
         </div>
+        {colorNotice && (
+          <p style={{ marginTop: 8, fontSize: 12, color: '#f59e0b' }}>{colorNotice}</p>
+        )}
       </div>
 
       <div className={styles.card}>


### PR DESCRIPTION
### Motivation
- Provide explicit actions for adding a custom color so users can choose either `Add to Avoid` or `Add to Emphasize` from the same input. 
- Normalize custom color payloads to a consistent `{ h, s, l, label }` shape and centralize logic to avoid duplication. 
- Prevent duplicate labels within a list and resolve conflicts where the same label exists in both lists by auto-moving or showing a notice. 

### Description
- Added a shared helper `addColorToTarget({ target, color })` that normalizes labels (case-insensitive), validates non-empty labels, performs duplicate checks, and updates `avoidColors` / `emphasizeColors` accordingly. 
- Introduced `createCustomColor()` to build the `{ h, s, l, label }` object from the current custom inputs and `colorNotice` state to surface validation/conflict messages. 
- Replaced the single `Add` button with two actions wired to `addCustomColorToAvoid` and `addCustomColorToEmphasize`, and updated preset buttons to call the new `addAvoid` / `addEmphasize` wrappers. 
- On conflict (label present in the opposite list), the code now auto-moves the label to the selected list and shows a notice; duplicate additions to the same list show a duplicate notice; the input label is cleared only after a successful add/move. 

### Testing
- Attempted `npm run build`, which failed in this environment because `vite` was not available (build step did not run). 
- Attempted `npm install`, which was blocked by the environment with `403 Forbidden` from the npm registry so dependencies could not be installed. 
- Attempted a Playwright page screenshot, which failed because the dev server at `http://127.0.0.1:5173` was not reachable (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7208940108323b0904236999aa89e)