### PR TITLE
Fix plugin/phaser generator split and executor allocation overlap

### DIFF
--- a/src/luagen/generatePlugin.js
+++ b/src/luagen/generatePlugin.js
@@ -4,11 +4,9 @@
 
 import { GENRE_PROFILES } from '../profiles/genreProfiles.js'
 import {
-  applyPreset,
   assignSequence,
   assignSequenceOption,
   attributeAt,
-  attributeEffect,
   clearAll,
   cmd,
   cueProperty,
@@ -25,7 +23,6 @@ export function generatePlugin(config) {
     emphasizeColors,
     page,
     startExec,
-    selectedPresetRefs = {},
   } = config
 
   const lines = []
@@ -82,82 +79,6 @@ export function generatePlugin(config) {
     lines.push(``)
     exec++
   }
-
-  lines.push(`  -- ╔══════════════════════════════╗`)
-  lines.push(`  -- ║  Phaser Sequences             ║`)
-  lines.push(`  -- ╚══════════════════════════════╝`)
-  lines.push(``)
-
-  const moverGroups = fixtureGroups.filter(g => g.attributes.pt)
-  const rgbGroups = fixtureGroups.filter(g => g.attributes.rgb || g.attributes.colorWheel)
-  const dimGroups = fixtureGroups
-
-  if (moverGroups.length > 0) {
-    lines.push(`  -- P/T Slow Phaser (Page ${page}, Exec ${exec})`)
-    lines.push(storeSequence('DP_PHASER_PT_SLOW'))
-    lines.push(labelSequence('DP_PHASER_PT_SLOW', 'DP Phaser PT Slow'))
-    for (const group of moverGroups) lines.push(selectGroup(group.maGroupName))
-    if (selectedPresetRefs.ptSlow) {
-      lines.push(`  -- Apply showfile preset before effect recipe`) 
-      lines.push(applyPreset(selectedPresetRefs.ptSlow))
-    }
-    lines.push(attributeEffect('Pan', 'Sinus Width 30 Rate 0.3'))
-    lines.push(attributeEffect('Tilt', 'Sinus Width 25 Rate 0.3 Phase 90'))
-    lines.push(storeSequence('DP_PHASER_PT_SLOW', 1, 'Merge'))
-    lines.push(assignSequence('DP_PHASER_PT_SLOW', `Page ${page} Exec ${exec}`))
-    lines.push(``)
-    exec++
-
-    lines.push(`  -- P/T Fast Phaser (Page ${page}, Exec ${exec})`)
-    lines.push(storeSequence('DP_PHASER_PT_FAST'))
-    lines.push(labelSequence('DP_PHASER_PT_FAST', 'DP Phaser PT Fast'))
-    for (const group of moverGroups) lines.push(selectGroup(group.maGroupName))
-    if (selectedPresetRefs.ptFast) {
-      lines.push(`  -- Apply showfile preset before effect recipe`)
-      lines.push(applyPreset(selectedPresetRefs.ptFast))
-    }
-    lines.push(attributeEffect('Pan', 'Sinus Width 45 Rate 1.2'))
-    lines.push(attributeEffect('Tilt', 'Sinus Width 35 Rate 1.2 Phase 90'))
-    lines.push(storeSequence('DP_PHASER_PT_FAST', 1, 'Merge'))
-    lines.push(assignSequence('DP_PHASER_PT_FAST', `Page ${page} Exec ${exec}`))
-    lines.push(``)
-    exec++
-  } else {
-    lines.push(`  -- Skipping P/T phasers (no Pan/Tilt groups defined)`)
-    exec += 2
-  }
-
-  if (rgbGroups.length > 0) {
-    lines.push(`  -- Color Chase (Page ${page}, Exec ${exec})`)
-    lines.push(storeSequence('DP_PHASER_COLOR'))
-    lines.push(labelSequence('DP_PHASER_COLOR', 'DP Color Chase'))
-    for (const group of rgbGroups) lines.push(selectGroup(group.maGroupName))
-    if (selectedPresetRefs.colorChase) {
-      lines.push(`  -- Apply showfile preset before effect recipe`)
-      lines.push(applyPreset(selectedPresetRefs.colorChase))
-    }
-    lines.push(attributeEffect('Hue', 'Sinus Width 180 Rate 0.5'))
-    lines.push(storeSequence('DP_PHASER_COLOR', 1, 'Merge'))
-    lines.push(assignSequence('DP_PHASER_COLOR', `Page ${page} Exec ${exec}`))
-    lines.push(``)
-    exec++
-  } else {
-    exec++
-  }
-
-  lines.push(`  -- Dimmer Pulse (Page ${page}, Exec ${exec})`)
-  lines.push(storeSequence('DP_PHASER_DIM'))
-  lines.push(labelSequence('DP_PHASER_DIM', 'DP Dimmer Pulse'))
-  for (const group of dimGroups) lines.push(selectGroup(group.maGroupName))
-  if (selectedPresetRefs.dimPulse) {
-    lines.push(`  -- Apply showfile preset before effect recipe`)
-    lines.push(applyPreset(selectedPresetRefs.dimPulse))
-  }
-  lines.push(attributeEffect('Dimmer', 'Square Width 50 Rate 1'))
-  lines.push(storeSequence('DP_PHASER_DIM', 1, 'Merge'))
-  lines.push(assignSequence('DP_PHASER_DIM', `Page ${page} Exec ${exec}`))
-  lines.push(``)
-  exec++
 
   lines.push(`  -- ╔══════════════╗`)
   lines.push(`  -- ║  Masters     ║`)

--- a/src/wizard/PhaserGenerator.jsx
+++ b/src/wizard/PhaserGenerator.jsx
@@ -8,8 +8,8 @@ export default function PhaserGenerator() {
   const [generated, setGenerated] = useState(false)
   const [luaCode, setLuaCode] = useState('')
 
-  // Phasers start 8 executors after the color looks (8 genres = exec 0–7, phasers = exec 8+)
-  const phaserExecStart = (session.freeExecutorStart || 1) + 8
+  // Main plugin uses 8 genre looks + 2 masters, so phasers start after that range.
+  const phaserExecStart = (session.freeExecutorStart || 1) + 10
 
   const generate = () => {
     const code = generatePhaserPlugin({

--- a/src/wizard/PluginGenerator.jsx
+++ b/src/wizard/PluginGenerator.jsx
@@ -15,7 +15,6 @@ export default function PluginGenerator() {
       emphasizeColors: session.emphasizeColors || [],
       page: session.freeExecutorPage,
       startExec: session.freeExecutorStart,
-      selectedPresetRefs: session.selectedPresetRefs || {},
     })
     setLuaCode(code)
     setGenerated(true)
@@ -57,7 +56,6 @@ export default function PluginGenerator() {
           in MA3's offline editor before running at a venue.
           <br /><br />
           Color look sequences use verified MA3 v2.x syntax and should work reliably.
-          For phaser sequences, use the separate <strong style={{ color: '#e0e0e0' }}>Phaser Plugin</strong> (next step).
         </p>
       </div>
 
@@ -65,15 +63,12 @@ export default function PluginGenerator() {
         <div className={styles.label}>What will be created</div>
         <ul style={{ fontSize: 13, color: '#aaa', lineHeight: 2, paddingLeft: 20, marginTop: 12 }}>
           <li>8 color look sequences (one per genre: Techno, EDM, Hip-Hop, Pop, 80s, Latin, Rock, Corporate)</li>
-          <li>2 Pan/Tilt phaser sequences (slow + fast), if you have mover groups</li>
-          <li>1 color chase phaser</li>
-          <li>1 dimmer pulse phaser</li>
           <li>1 BPM Rate Master executor</li>
           <li>1 Effect Size Master executor</li>
         </ul>
         <p style={{ fontSize: 13, color: '#f59e0b', marginTop: 12 }}>
           All sequences will be placed on <strong>Page {session.freeExecutorPage}</strong>,
-          Executors {session.freeExecutorStart}–{(session.freeExecutorStart || 1) + 13}.
+          Executors {session.freeExecutorStart}–{(session.freeExecutorStart || 1) + 9}.
           Nothing outside this range will be touched.
         </p>
       </div>


### PR DESCRIPTION
## Summary
- removed phaser-sequence generation from `generatePlugin` so the main plugin only creates color looks + masters
- updated `PluginGenerator` messaging and executor range to match the main plugin output (10 executors total)
- shifted `PhaserGenerator` start executor offset from `+8` to `+10` so phaser executors no longer collide with the two master executors

## Why
The recent split introduced a separate phaser plugin, but the main generator still created phaser sequences and UI text still claimed they were created there. It also caused executor overlap (`+8`) between phasers and masters.

## Impact
- no duplicate phaser creation in the main plugin
- no page/exec collisions between main and phaser generated content
- wizard UI now reflects actual generated outputs

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b74e91d47c8323bbb9dac774a2c236)